### PR TITLE
Bump version in acalc/manifest.json

### DIFF
--- a/apps/acalc/manifest.json
+++ b/apps/acalc/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_Calc_Message_CalcName__",
-  "version": "2.2.1",
+  "version": "2.2.4",
   "manifest_version": 2,
   "default_locale": "en",
 


### PR DESCRIPTION
The version was bumped manually whenever a release happened but wasn't reflected back here, this matches the code with the latest internal release.