### PR TITLE
fixed lingering a11y issues

### DIFF
--- a/apps/acalc/manifest.json
+++ b/apps/acalc/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_Calc_Message_CalcName__",
-  "version": "2.2.1",
+  "version": "2.2.5",
   "manifest_version": 2,
   "default_locale": "en",
 

--- a/js/foam/apps/calc/Calc.js
+++ b/js/foam/apps/calc/Calc.js
@@ -151,7 +151,12 @@ CLASS({
         element: this.X.$$('calc-display')[0],
         color: '#f44336' /* red */
       }).fire, 100);
-      this.history.put(this.History.create(this));
+      this.history.put(this.History.create({
+        op: this.op,
+        a2: this.a2,
+        index: this.history.length,
+        numberFormatter: this.numberFormatter
+      }));
       this.a1   = 0;
       this.a2   = '';
       this.op   = this.DEFAULT_OP;
@@ -162,7 +167,12 @@ CLASS({
       if ( a2 != this.a2 ||
            ( opt_op || this.DEFAULT_OP ) != this.op )
         this.row1 = '';
-      this.history.put(this.History.create(this));
+      this.history.put(this.History.create({
+        op: this.op,
+        a2: this.a2,
+        index: this.history.length,
+        numberFormatter: this.numberFormatter
+      }));
       while ( this.history.length > this.MAX_HISTORY ) this.history.shift();
       this.a1 = this.a2;
       this.op = opt_op || this.DEFAULT_OP;

--- a/js/foam/apps/calc/CalcView.js
+++ b/js/foam/apps/calc/CalcView.js
@@ -107,7 +107,6 @@ CLASS({
 
       this.$.querySelector('.keypad').addEventListener('mousedown', function(e) { e.preventDefault(); return false; });
       this.document.body.setAttribute('aria-label', this.data.model_.CALC_NAME.value);
-
     },
     addArrowData: function(e, data) {
       e.setAttribute('data-arrow-up', data[0])
@@ -159,32 +158,6 @@ CLASS({
         // also fix the aria label of the first
         const historyNodeList = document.querySelectorAll('.history');
         const history = Array(historyNodeList.length).fill(0).map((_,i) => historyNodeList[i])
-
-        // The way the history is set up means that every element in the history
-        // has to be rendered the same way, as such every other number element
-        // has the aria label "equals <num>". This means as you are tabbing
-        // through something such as
-        //
-        //  A
-        //  + B
-        // --------
-        //  C
-        //
-        // The screen reader helpfully announces "A + B equals C" as "C" has
-        // the "equals C" aria label. Sadly we don't want this label on A, only
-        // on C and any subsequent numbers. This bit of JS removes that label
-        // from the first element in the history.
-
-        const equalsMessage = window.chrome.i18n &&
-          window.chrome.i18n.getMessage('Calc_ActionSpeechLabel_equals')
-          || 'equals';
-
-        if (history[0] && history[0].getAttribute('aria-label')) {
-          let ariaLabel = history[0].getAttribute('aria-label');
-          ariaLabel = ariaLabel.replace(new RegExp('^'+equalsMessage),'');
-          history[0].setAttribute('aria-label', ariaLabel);
-        }
-
 
         let prev = {elem: document.body, selector: 'body'};
 
@@ -431,11 +404,6 @@ CLASS({
       position: absolute;
       z-index: 1;
     }
-
-    #deg-label:focus>span{
-      color: rgba(52, 153, 128, 0.65);
-      font-weight: bold;
-    }
   */},
     {
       name: 'toHTML',
@@ -444,11 +412,9 @@ CLASS({
         <!-- <%= this.ZoomView.create() %> -->
         <% X.registerModel(this.CalcButton, 'foam.ui.ActionButton'); %>
         <div id="%%id" class="CalcView">
-        <div style="position: relative; z-index: 1;">
+        <div style="position: relative; z-index: 1;" tabindex="-1" aria-hidden="true">
           <div
             id="deg-label"
-            tabindex="1"
-            aria-label="<%= (this.data.degreesMode ? this.data.model_.DEG.label : this.data.model_.RAD.label) %>"
           >
             <span
               style="top: 15px;left: 0;position: absolute; z-index: 1;"

--- a/js/foam/apps/calc/History.js
+++ b/js/foam/apps/calc/History.js
@@ -23,7 +23,8 @@ CLASS({
     {
       name: 'a2',
       preSet: function(_, n) { return this.formatNumber(n); }
-    }
+    },
+    'index'
   ],
   methods: {
     formatNumber: function(n) {

--- a/js/foam/apps/calc/HistoryCitationView.js
+++ b/js/foam/apps/calc/HistoryCitationView.js
@@ -15,10 +15,10 @@ CLASS({
   extends: 'foam.ui.View',
   templates: [
     function toHTML() {/*
-      <div class="history" role="listitem" tabindex="2" <% if ( !this.data.op.label ) { %> aria-label="{{window.chrome.i18n ? window.chrome.i18n.getMessage('Calc_ActionSpeechLabel_equals') + ' ' : 'equals '}}{{this.data.a2}}" <% } %>>
-        {{{this.data.op.label}}}&nbsp;{{this.data.a2}}
+      <div class="history" role="listitem" tabindex="2" aria-label="{{(this.data.index > 0 && !this.data.op.label) ? (window.chrome.i18n ? window.chrome.i18n.getMessage('Calc_ActionSpeechLabel_equals') + ' ' : 'equals ') : ''}}{{this.data.op.speechLabel}} {{this.data.a2}}">
+        <span aria-hidden="true">{{{this.data.op.label}}}&nbsp;{{this.data.a2}}<span>
       </div>
-      <% if ( this.data.op.label ) { %><hr><% } %>
+      <% if ( this.data.op.label ) { %><hr aria-hidden="true"><% } %>
     */}
   ]
 });

--- a/js/foam/graphics/AbstractCViewView.js
+++ b/js/foam/graphics/AbstractCViewView.js
@@ -180,7 +180,7 @@ CLASS({
             msg = window.chrome.i18n.getMessage('Calc_ActionSpeechLabel_'+btnId);
           } else {
             // Silently fail since there is no way to recover from this.
-            console.warning('Could not access i18n tools, arrow nav disabled');
+            console.warn('Could not access i18n tools, arrow nav disabled');
             return;
           }
           // If we are targeting a number it has no translated label.

--- a/js/foam/ui/animated/Label.js
+++ b/js/foam/ui/animated/Label.js
@@ -85,7 +85,7 @@ CLASS({
         var f2$ = this.$.querySelector('.f2');
 
         var data = this.data || '&nbsp;';
-        f1$.innerHTML = data;
+        f1$.innerHTML = `<span aria-hidden="true">${data}</span>`;
         f2$.innerHTML = data;
 
         f1$.style.left = f2$.offsetLeft + 'px';


### PR DESCRIPTION
1. Fixes issues with using search + arrow keys to navigate
3. Cleans up the way we add aria labels to history items so it's more robust.
4. Takes deg/rad label out of the tab order / search order entirely, it only adds confusion and reading out the current state of the app is already covered by the 's' shortcut.