### PR TITLE
Fixed readout for history + buttons

### DIFF
--- a/js/foam/apps/calc/Calc.js
+++ b/js/foam/apps/calc/Calc.js
@@ -154,7 +154,7 @@ CLASS({
       this.history.put(this.History.create({
         op: this.op,
         a2: this.a2,
-        index: this.history.length,
+        sayEquals: this.shouldSayEqual(),
         numberFormatter: this.numberFormatter
       }));
       this.a1   = 0;
@@ -163,6 +163,25 @@ CLASS({
       this.row1 = '';
       this.editable = true;
     },
+    /**
+     * Returns if the next item in history should be announced with a
+     * preceding 'equals'.
+     */
+    function shouldSayEqual() {
+      // First ever entry should never have equals.
+      if (this.history.length === 0) {
+        return false;
+      }
+      // Any line with a operator (+,- etc.) should never.
+      if (this.op.label) {
+        return false;
+      }
+      // If the previous line announced equal this one should not.
+      if (this.history[this.history.length -1].sayEquals) {
+        return false;
+      }
+      return true;
+    },
     function push(a2, opt_op) {
       if ( a2 != this.a2 ||
            ( opt_op || this.DEFAULT_OP ) != this.op )
@@ -170,7 +189,7 @@ CLASS({
       this.history.put(this.History.create({
         op: this.op,
         a2: this.a2,
-        index: this.history.length,
+        sayEquals: this.shouldSayEqual(),
         numberFormatter: this.numberFormatter
       }));
       while ( this.history.length > this.MAX_HISTORY ) this.history.shift();

--- a/js/foam/apps/calc/History.js
+++ b/js/foam/apps/calc/History.js
@@ -24,7 +24,7 @@ CLASS({
       name: 'a2',
       preSet: function(_, n) { return this.formatNumber(n); }
     },
-    'index'
+    'sayEquals'
   ],
   methods: {
     formatNumber: function(n) {

--- a/js/foam/apps/calc/HistoryCitationView.js
+++ b/js/foam/apps/calc/HistoryCitationView.js
@@ -15,7 +15,7 @@ CLASS({
   extends: 'foam.ui.View',
   templates: [
     function toHTML() {/*
-      <div class="history" role="listitem" tabindex="2" aria-label="{{(this.data.index > 0 && !this.data.op.label) ? (window.chrome.i18n ? window.chrome.i18n.getMessage('Calc_ActionSpeechLabel_equals') + ' ' : 'equals ') : ''}}{{this.data.op.speechLabel}} {{this.data.a2}}">
+      <div class="history" role="listitem" tabindex="2" aria-label="{{(this.data.sayEquals) ? (window.chrome.i18n ? window.chrome.i18n.getMessage('Calc_ActionSpeechLabel_equals') + ' ' : 'equals ') : ''}}{{this.data.op.speechLabel}} {{this.data.a2}}">
         <span aria-hidden="true">{{{this.data.op.label}}}&nbsp;{{this.data.a2}}<span>
       </div>
       <% if ( this.data.op.label ) { %><hr aria-hidden="true"><% } %>

--- a/js/foam/graphics/AbstractCViewView.js
+++ b/js/foam/graphics/AbstractCViewView.js
@@ -66,7 +66,7 @@ CLASS({
     'arrowNav',
     {
       name: 'ariaPressed',
-      defaultValue: false
+      defaultValue: undefined
     },
     {
       type: 'Int',
@@ -125,7 +125,8 @@ CLASS({
       isFramed: true,
       code: function() {
         if ( ! this.$ ) throw EventService.UNSUBSCRIBE_EXCEPTION;
-        this.$.setAttribute('aria-pressed', this.ariaPressed);
+        if (this.ariaPressed !== undefined && this.ariaPressed !== '')
+          this.$.setAttribute('aria-pressed', this.ariaPressed);
         this.canvas.save();
 
         this.canvas.clearRect(0, 0, this.canvasWidth(), this.canvasHeight());

--- a/js/foam/graphics/ActionButtonCView.js
+++ b/js/foam/graphics/ActionButtonCView.js
@@ -130,7 +130,7 @@ CLASS({
     'role',
     {
       name: 'ariaPressed',
-      defaultValue: false
+      defaultValue: undefined
     },
     {
       name: 'state_',

--- a/js/foam/ui/animated/Label.js
+++ b/js/foam/ui/animated/Label.js
@@ -95,14 +95,23 @@ CLASS({
 
         // update speech label
         this.$.querySelector('.f1').setAttribute('tabindex', 3);
-        this.$.querySelector('.f1').setAttribute('aria-label', newValue !== undefined ? newValue : 'Blank')
+        // The value will sometimes have markup, remove it.
+        if (newValue !== undefined) {
+          newValue = newValue.replace(/\<[^\<\>]+\>/g, '');
+          newValue = newValue.replace(/\&nbsp\;/g, '');
+        }
+        
+        this.$.querySelector('.f1').setAttribute(
+            'aria-label',
+            newValue !== undefined ? newValue :
+                                     'Blank');
       }
     },
     {
       name: 'onResize',
       isFramed: true,
       code: function() {
-        if ( ! this.$ ) return;
+        if (!this.$) return;
         DOM.setClass(this.$.querySelector('.f1'), 'animated', false);
         this.onDataChange();
       }


### PR DESCRIPTION
Fixes normal buttons so they no longer register as toggle buttons to chromevox.
Fixed bug where chromevox would announce "equals" on history items that were not actually calculation results.